### PR TITLE
Add width arrays for each agent

### DIFF
--- a/env/axi4_env_config.sv
+++ b/env/axi4_env_config.sv
@@ -25,6 +25,31 @@ class axi4_env_config extends uvm_object;
   // Number of masters connected to the AXI interface
   int no_of_masters;
 
+  // Variable: master_address_width
+  // Array storing address width for each master. Default value is ADDRESS_WIDTH
+  int master_address_width[];
+
+  // Variable: master_data_width
+  // Array storing data width for each master. Default value is DATA_WIDTH
+  int master_data_width[];
+
+  // Variable: slave_address_width
+  // Array storing address width for each slave. Default value is ADDRESS_WIDTH
+  int slave_address_width[];
+
+  // Variable: slave_data_width
+  // Array storing data width for each slave. Default value is DATA_WIDTH
+  int slave_data_width[];
+
+  // constraint : width_limit_c
+  // Restrict widths for master and slave based on AMBA4 specification
+  constraint width_limit_c {
+    foreach(master_address_width[i]) master_address_width[i] <= 64;
+    foreach(slave_address_width[i])  slave_address_width[i]  <= 64;
+    foreach(master_data_width[i])    master_data_width[i]    inside {32,64,128,256,512,1024};
+    foreach(slave_data_width[i])     slave_data_width[i]     inside {32,64,128,256,512,1024};
+  }
+
   // Variable: master_agent_cfg_h
   // Handle for axi4 master agent configuration
   axi4_master_agent_config axi4_master_agent_cfg_h[];
@@ -66,6 +91,18 @@ function void axi4_env_config::do_print(uvm_printer printer);
   printer.print_field ("has_virtual_sqr",has_virtual_seqr,1, UVM_DEC);
   printer.print_field ("no_of_masters",no_of_masters,$bits(no_of_masters), UVM_HEX);
   printer.print_field ("no_of_slaves",no_of_slaves,$bits(no_of_slaves), UVM_HEX);
+  foreach(master_address_width[i]) begin
+    printer.print_field($sformatf("master_address_width[%0d]",i),
+                        master_address_width[i],$bits(master_address_width[i]),UVM_DEC);
+    printer.print_field($sformatf("master_data_width[%0d]",i),
+                        master_data_width[i],$bits(master_data_width[i]),UVM_DEC);
+  end
+  foreach(slave_address_width[i]) begin
+    printer.print_field($sformatf("slave_address_width[%0d]",i),
+                        slave_address_width[i],$bits(slave_address_width[i]),UVM_DEC);
+    printer.print_field($sformatf("slave_data_width[%0d]",i),
+                        slave_data_width[i],$bits(slave_data_width[i]),UVM_DEC);
+  end
   printer.print_string ("transfer_type",   write_read_mode_h.name());
 
 endfunction : do_print

--- a/intf/axi4_interface/axi4_if.sv
+++ b/intf/axi4_interface/axi4_if.sv
@@ -8,7 +8,10 @@ import axi4_globals_pkg::*;
 // Interface : axi4_if
 // Declaration of pin level signals for axi4 interface
 //--------------------------------------------------------------------------------------------
-interface axi4_if(input aclk, input aresetn);
+interface axi4_if#(
+  parameter int ADDRESS_WIDTH = axi4_globals_pkg::ADDRESS_WIDTH,
+  parameter int DATA_WIDTH    = axi4_globals_pkg::DATA_WIDTH
+)(input aclk, input aresetn);
 
   //Write_address_channel
   logic     [3: 0] awid     ;

--- a/master/axi4_master_agent_config.sv
+++ b/master/axi4_master_agent_config.sv
@@ -17,6 +17,21 @@ class axi4_master_agent_config extends uvm_object;
   //Used for enabling the master agent coverage
   bit has_coverage;
 
+  //Variable: address_width
+  //Width of the master's address bus. Default value is ADDRESS_WIDTH
+  int address_width = ADDRESS_WIDTH;
+
+  //Variable: data_width
+  //Width of the master's data bus. Default value is DATA_WIDTH
+  int data_width = DATA_WIDTH;
+
+  //constraint: width_limit_c
+  //Restrict master widths based on AMBA4 specification
+  constraint width_limit_c {
+    address_width <= 64;
+    data_width inside {32,64,128,256,512,1024};
+  }
+
   //Variable : master_memory
   //Used to store all the data from the slaves
   //Each location of the master memory stores 32 bit data
@@ -116,6 +131,8 @@ function void axi4_master_agent_config::do_print(uvm_printer printer);
   
   printer.print_string ("is_active",is_active.name());
   printer.print_field ("has_coverage",  has_coverage, $bits(has_coverage),  UVM_DEC);
+  printer.print_field ("address_width", address_width, $bits(address_width), UVM_DEC);
+  printer.print_field ("data_width", data_width, $bits(data_width), UVM_DEC);
   
   //Memory Mapping Minimum and Maximum Address Range 
   foreach(master_max_addr_range_array[i]) begin

--- a/slave/axi4_slave_agent_config.sv
+++ b/slave/axi4_slave_agent_config.sv
@@ -16,6 +16,14 @@ class axi4_slave_agent_config extends uvm_object;
   //Used for enabling the master agent coverage
   bit has_coverage;
 
+  //Variable: address_width
+  //Width of the slave's address bus. Default value is ADDRESS_WIDTH
+  int address_width = ADDRESS_WIDTH;
+
+  //Variable: data_width
+  //Width of the slave's data bus. Default value is DATA_WIDTH
+  int data_width = DATA_WIDTH;
+
   //Variable: slave_id
   //Gives the slave id
   int slave_id;
@@ -59,6 +67,13 @@ class axi4_slave_agent_config extends uvm_object;
   //Used to set default read data
   bit[DATA_WIDTH-1:0] user_rdata;
 
+  //constraint: width_limit_c
+  //Restrict slave widths based on AMBA4 specification
+  constraint width_limit_c {
+    address_width <= 64;
+    data_width inside {32,64,128,256,512,1024};
+  }
+
   //constraint: maximum_txns
   //Make sure to have minimum txns to perform out_of_order
   constraint maximum_txns_c{maximum_transactions >= minimum_transactions;}
@@ -99,6 +114,8 @@ function void axi4_slave_agent_config::do_print(uvm_printer printer);
   printer.print_string ("is_active",   is_active.name());
   printer.print_field ("slave_id",     slave_id,     $bits(slave_id),     UVM_DEC);
   printer.print_field ("has_coverage", has_coverage, $bits(has_coverage), UVM_DEC);
+  printer.print_field ("address_width", address_width, $bits(address_width), UVM_DEC);
+  printer.print_field ("data_width", data_width, $bits(data_width), UVM_DEC);
   printer.print_field ("min_address",  min_address,  $bits(max_address),  UVM_HEX);
   printer.print_field ("max_address",  max_address,  $bits(max_address),  UVM_HEX);
   printer.print_string ("slave_response_type",   slave_response_mode.name());

--- a/test/axi4_base_test.sv
+++ b/test/axi4_base_test.sv
@@ -73,6 +73,19 @@ function void axi4_base_test:: setup_axi4_env_cfg();
   axi4_env_cfg_h.has_virtual_seqr = 1;
   axi4_env_cfg_h.no_of_masters = NO_OF_MASTERS;
   axi4_env_cfg_h.no_of_slaves = NO_OF_SLAVES;
+  axi4_env_cfg_h.master_address_width = new[NO_OF_MASTERS];
+  axi4_env_cfg_h.master_data_width    = new[NO_OF_MASTERS];
+  foreach(axi4_env_cfg_h.master_address_width[i]) begin
+    axi4_env_cfg_h.master_address_width[i] = ADDRESS_WIDTH;
+    axi4_env_cfg_h.master_data_width[i]    = DATA_WIDTH;
+  end
+
+  axi4_env_cfg_h.slave_address_width  = new[NO_OF_SLAVES];
+  axi4_env_cfg_h.slave_data_width     = new[NO_OF_SLAVES];
+  foreach(axi4_env_cfg_h.slave_address_width[i]) begin
+    axi4_env_cfg_h.slave_address_width[i] = ADDRESS_WIDTH;
+    axi4_env_cfg_h.slave_data_width[i]    = DATA_WIDTH;
+  end
 
   // Setup the axi4_master agent cfg 
   setup_axi4_master_agent_cfg();
@@ -102,8 +115,10 @@ function void axi4_base_test::setup_axi4_master_agent_cfg();
     axi4_env_cfg_h.axi4_master_agent_cfg_h[i] =
     axi4_master_agent_config::type_id::create($sformatf("axi4_master_agent_cfg_h[%0d]",i));
     axi4_env_cfg_h.axi4_master_agent_cfg_h[i].is_active   = uvm_active_passive_enum'(UVM_ACTIVE);
-    axi4_env_cfg_h.axi4_master_agent_cfg_h[i].has_coverage = 1; 
+    axi4_env_cfg_h.axi4_master_agent_cfg_h[i].has_coverage = 1;
     axi4_env_cfg_h.axi4_master_agent_cfg_h[i].qos_mode_type = QOS_MODE_DISABLE;
+    axi4_env_cfg_h.axi4_master_agent_cfg_h[i].address_width = axi4_env_cfg_h.master_address_width[i];
+    axi4_env_cfg_h.axi4_master_agent_cfg_h[i].data_width    = axi4_env_cfg_h.master_data_width[i];
   end
 
   for(int i =0; i<NO_OF_SLAVES; i++) begin
@@ -152,6 +167,8 @@ function void axi4_base_test::setup_axi4_slave_agent_cfg();
     axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = RANDOM_DATA_MODE;
     axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].slave_response_mode = RESP_IN_ORDER;
     axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].qos_mode_type = QOS_MODE_DISABLE;
+    axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].address_width = axi4_env_cfg_h.slave_address_width[i];
+    axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].data_width    = axi4_env_cfg_h.slave_data_width[i];
 
     
     if(SLAVE_AGENT_ACTIVE === 1) begin

--- a/top/hdl_top.sv
+++ b/top/hdl_top.sv
@@ -49,8 +49,13 @@ module hdl_top;
 
   // Variable : intf
   // axi4 Interface Instantiation
-  axi4_if intf(.aclk(aclk),
-               .aresetn(aresetn));
+  axi4_if #(
+    .ADDRESS_WIDTH(ADDRESS_WIDTH),
+    .DATA_WIDTH(DATA_WIDTH)
+  ) intf(
+    .aclk(aclk),
+    .aresetn(aresetn)
+  );
 
   //-------------------------------------------------------
   // AXI4  No of Master and Slaves Agent Instantiation


### PR DESCRIPTION
## Summary
- store address/data width per master and slave in arrays
- propagate per-agent widths during test setup

## Testing
- `verilator --version` *(fails: command not found)*
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6846682695e88320b9a2e84cf87631ad