### PR TITLE
Fix width functional coverage test hang

### DIFF
--- a/virtual_seq/axi4_virtual_write_read_seq.sv
+++ b/virtual_seq/axi4_virtual_write_read_seq.sv
@@ -22,10 +22,10 @@ class axi4_virtual_write_read_seq extends axi4_virtual_base_seq;
   axi4_slave_bk_read_seq axi4_slave_bk_read_seq_h;
   axi4_slave_nbk_read_seq axi4_slave_nbk_read_seq_h;
 
-  process blocking_master_wr_seq;
-  process blocking_master_rd_seq;
-  process blocking_slave_wr_seq;
-  process blocking_slave_rd_seq;
+  // Processes used earlier to synchronize slave sequences with the
+  // master sequences were leaving background threads running forever
+  // causing tests to hang.  These handles are no longer required
+  // after replacing the infinite loops with bounded repeats.
 
   //-------------------------------------------------------
   // Externally defined Tasks and Functions
@@ -62,56 +62,51 @@ task axi4_virtual_write_read_seq::body();
 
   `uvm_info(get_type_name(), $sformatf("DEBUG_MSHA :: Insdie axi4_virtual_write_read_seq"), UVM_NONE); 
 
-  fork 
+  // Run a limited number of slave sequences to avoid infinite background
+  // threads which prevented the test from completing.  The slave sequences
+  // now mirror the number of master transactions issued below.
+  fork
     begin : T1_BK_SL_WR
-      forever begin
-        blocking_slave_wr_seq = process::self();
+      repeat(5) begin
         axi4_slave_bk_write_seq_h.start(p_sequencer.axi4_slave_write_seqr_h);
       end
     end
     begin : T2_BK_SL_RD
-      forever begin
-        blocking_slave_rd_seq = process::self();
+      repeat(3) begin
         axi4_slave_bk_read_seq_h.start(p_sequencer.axi4_slave_read_seqr_h);
       end
     end
     begin : T1_NBK_SL_WR
-      forever begin
-        blocking_slave_wr_seq.await();
+      repeat(5) begin
         axi4_slave_nbk_write_seq_h.start(p_sequencer.axi4_slave_write_seqr_h);
       end
     end
     begin : T2_NBK_SL_RD
-      forever begin
-        blocking_slave_rd_seq.await();
+      repeat(3) begin
         axi4_slave_nbk_read_seq_h.start(p_sequencer.axi4_slave_read_seqr_h);
       end
     end
   join_none
 
 
-  fork 
+  fork
     begin: T1_BK_WRITE
-      blocking_master_wr_seq = process::self();
       repeat(5) begin
         axi4_master_bk_write_seq_h.start(p_sequencer.axi4_master_write_seqr_h);
       end
     end
     begin: T2_BK_READ
-      blocking_master_rd_seq = process::self();
       repeat(3) begin
         axi4_master_bk_read_seq_h.start(p_sequencer.axi4_master_read_seqr_h);
       end
     end
     begin: T1_NBK_WRITE
       repeat(5) begin
-        blocking_master_wr_seq.await();
         axi4_master_nbk_write_seq_h.start(p_sequencer.axi4_master_write_seqr_h);
       end
     end
     begin: T2_NBK_READ
       repeat(3) begin
-        blocking_master_rd_seq.await();
         axi4_master_nbk_read_seq_h.start(p_sequencer.axi4_master_read_seqr_h);
       end
     end


### PR DESCRIPTION
## Summary
- remove persistent process handles in `axi4_virtual_write_read_seq`
- replace slave `forever` loops with bounded repeats to match master transactions

## Testing
- `make -f sim/questasim/makefile -n compile` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_6849a46eb3cc8320a77b68fd102e1422