### PR TITLE
Fix scoreboard errors in aw ready delay tests

### DIFF
--- a/test/axi4_ar_ready_delay_test.sv
+++ b/test/axi4_ar_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_ar_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_ar_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_READ_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_ar_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_aw_ready_delay_test.sv
+++ b/test/axi4_aw_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_aw_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_aw_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_aw_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_aw_w_channel_separation_test.sv
+++ b/test/axi4_aw_w_channel_separation_test.sv
@@ -6,6 +6,11 @@ class axi4_aw_w_channel_separation_test extends axi4_base_test;
 
   axi4_virtual_aw_w_channel_separation_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_aw_w_channel_separation_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_b_ready_delay_test.sv
+++ b/test/axi4_b_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_b_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_b_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_b_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_r_ready_delay_test.sv
+++ b/test/axi4_r_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_r_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_r_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_READ_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_r_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_w_ready_delay_test.sv
+++ b/test/axi4_w_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_w_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_w_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_w_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction


### PR DESCRIPTION
## Summary
- ensure various ready delay tests configure write or read mode correctly
- avoid scoreboard read/write mismatches by overriding environment setup

## Testing
- `make compile` (fails: `vlib` not found)


------
https://chatgpt.com/codex/tasks/task_e_684c409e54888320b4ec6452bb4d6f8b