### PR TITLE
Improve handshake and wait state coverage

### DIFF
--- a/master/axi4_master_coverage.sv
+++ b/master/axi4_master_coverage.sv
@@ -198,9 +198,19 @@ class axi4_master_coverage extends uvm_subscriber #(axi4_master_tx);
       bins AW_WS[] = {[0:6]};
     }
 
+    AW_HANDSHAKE_CP : coverpoint (packet.aw_wait_states == 0) {
+      option.comment = "AWREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     W_WAIT_STATES_CP : coverpoint packet.w_wait_states {
       option.comment = "WREADY wait states";
       bins W_WS[] = {[0:6]};
+    }
+
+    W_HANDSHAKE_CP : coverpoint (packet.w_wait_states == 0) {
+      option.comment = "WREADY handshake";
+      bins HANDSHAKE = {1};
     }
 
     B_WAIT_STATES_CP : coverpoint packet.b_wait_states {
@@ -208,14 +218,29 @@ class axi4_master_coverage extends uvm_subscriber #(axi4_master_tx);
       bins B_WS[] = {[0:6]};
     }
 
+    B_HANDSHAKE_CP : coverpoint (packet.b_wait_states == 0) {
+      option.comment = "BREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     AR_WAIT_STATES_CP : coverpoint packet.ar_wait_states {
       option.comment = "ARREADY wait states";
       bins AR_WS[] = {[0:6]};
     }
 
+    AR_HANDSHAKE_CP : coverpoint (packet.ar_wait_states == 0) {
+      option.comment = "ARREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     R_WAIT_STATES_CP : coverpoint packet.r_wait_states {
       option.comment = "RREADY wait states";
       bins R_WS[] = {[0:6]};
+    }
+
+    R_HANDSHAKE_CP : coverpoint (packet.r_wait_states == 0) {
+      option.comment = "RREADY handshake";
+      bins HANDSHAKE = {1};
     }
     TRANSFER_TYPE_CP : coverpoint packet.transfer_type {
       option.comment = "transfer type";

--- a/seq/master_sequences/axi4_master_b_ready_delay_seq.sv
+++ b/seq/master_sequences/axi4_master_b_ready_delay_seq.sv
@@ -14,22 +14,24 @@ endfunction : new
 
 task axi4_master_b_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.awid == 4'h7;
-                            req.awaddr == 32'h00001088;
-                            req.awlen == 0;
-                            req.awsize == WRITE_4_BYTES;
-                            req.tx_type == WRITE;
-                            req.transfer_type == BLOCKING_WRITE;
-                            req.b_wait_states == 4;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.awid == 4'h7;
+                              req.awaddr == 32'h00001088;
+                              req.awlen == 0;
+                              req.awsize == WRITE_4_BYTES;
+                              req.tx_type == WRITE;
+                              req.transfer_type == BLOCKING_WRITE;
+                              req.b_wait_states == ws;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    req.wdata.delete();
+    req.wdata.push_back(32'hCAFEBABE);
+    req.wstrb.delete();
+    req.wstrb.push_back('hf);
+    req.wlast = 1'b1;
+    finish_item(req);
   end
-  req.wdata.delete();
-  req.wdata.push_back(32'hCAFEBABE);
-  req.wstrb.delete();
-  req.wstrb.push_back('hf);
-  req.wlast = 1'b1;
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/master_sequences/axi4_master_r_ready_delay_seq.sv
+++ b/seq/master_sequences/axi4_master_r_ready_delay_seq.sv
@@ -14,17 +14,19 @@ endfunction : new
 
 task axi4_master_r_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.arid == 4'h8;
-                            req.araddr == 32'h00001090;
-                            req.arlen == 0;
-                            req.arsize == READ_4_BYTES;
-                            req.tx_type == READ;
-                            req.transfer_type == BLOCKING_READ;
-                            req.r_wait_states == 6;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.arid == 4'h8;
+                              req.araddr == 32'h00001090;
+                              req.arlen == 0;
+                              req.arsize == READ_4_BYTES;
+                              req.tx_type == READ;
+                              req.transfer_type == BLOCKING_READ;
+                              req.r_wait_states == ws;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_ar_ready_delay_seq.sv
+++ b/seq/slave_sequences/axi4_slave_ar_ready_delay_seq.sv
@@ -14,12 +14,14 @@ endfunction : new
 
 task axi4_slave_ar_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.ar_wait_states == 2;
-                            req.r_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.ar_wait_states == ws;
+                              req.r_wait_states == 0;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_aw_ready_delay_seq.sv
+++ b/seq/slave_sequences/axi4_slave_aw_ready_delay_seq.sv
@@ -14,13 +14,15 @@ endfunction : new
 
 task axi4_slave_aw_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.aw_wait_states == 5;
-                            req.w_wait_states == 0;
-                            req.b_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.aw_wait_states == ws;
+                              req.w_wait_states == 0;
+                              req.b_wait_states == 0;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_aw_w_channel_separation_seq.sv
+++ b/seq/slave_sequences/axi4_slave_aw_w_channel_separation_seq.sv
@@ -14,13 +14,15 @@ endfunction : new
 
 task axi4_slave_aw_w_channel_separation_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.aw_wait_states == 0;
-                            req.w_wait_states == 0;
-                            req.b_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.aw_wait_states == ws;
+                              req.w_wait_states == ws;
+                              req.b_wait_states == 0;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_b_ready_delay_seq.sv
+++ b/seq/slave_sequences/axi4_slave_b_ready_delay_seq.sv
@@ -14,13 +14,15 @@ endfunction : new
 
 task axi4_slave_b_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.aw_wait_states == 0;
-                            req.w_wait_states == 0;
-                            req.b_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.aw_wait_states == 0;
+                              req.w_wait_states == 0;
+                              req.b_wait_states == ws;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_r_ready_delay_seq.sv
+++ b/seq/slave_sequences/axi4_slave_r_ready_delay_seq.sv
@@ -14,14 +14,16 @@ endfunction : new
 
 task axi4_slave_r_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.ar_wait_states == 0;
-                            req.r_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.ar_wait_states == 0;
+                              req.r_wait_states == ws;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    req.rdata.delete();
+    req.rdata.push_back(32'hEEEEFFFF);
+    finish_item(req);
   end
-  req.rdata.delete();
-  req.rdata.push_back(32'hEEEEFFFF);
-  finish_item(req);
 endtask : body
 
 `endif

--- a/seq/slave_sequences/axi4_slave_w_ready_delay_seq.sv
+++ b/seq/slave_sequences/axi4_slave_w_ready_delay_seq.sv
@@ -14,13 +14,15 @@ endfunction : new
 
 task axi4_slave_w_ready_delay_seq::body();
   super.body();
-  start_item(req);
-  if(!req.randomize() with {req.aw_wait_states == 0;
-                            req.w_wait_states == 3;
-                            req.b_wait_states == 0;}) begin
-    `uvm_fatal("axi4","Rand failed")
+  for(int ws = 0; ws <= 6; ws++) begin
+    start_item(req);
+    if(!req.randomize() with {req.aw_wait_states == 0;
+                              req.w_wait_states == ws;
+                              req.b_wait_states == 0;}) begin
+      `uvm_fatal("axi4","Rand failed")
+    end
+    finish_item(req);
   end
-  finish_item(req);
 endtask : body
 
 `endif

--- a/slave/axi4_slave_coverage.sv
+++ b/slave/axi4_slave_coverage.sv
@@ -197,9 +197,19 @@ class axi4_slave_coverage extends uvm_subscriber#(axi4_slave_tx);
       bins AW_WS[] = {[0:6]};
     }
 
+    AW_HANDSHAKE_CP : coverpoint (packet.aw_wait_states == 0) {
+      option.comment = "AWREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     W_WAIT_STATES_CP : coverpoint packet.w_wait_states {
       option.comment = "WREADY wait states";
       bins W_WS[] = {[0:6]};
+    }
+
+    W_HANDSHAKE_CP : coverpoint (packet.w_wait_states == 0) {
+      option.comment = "WREADY handshake";
+      bins HANDSHAKE = {1};
     }
 
     B_WAIT_STATES_CP : coverpoint packet.b_wait_states {
@@ -207,14 +217,29 @@ class axi4_slave_coverage extends uvm_subscriber#(axi4_slave_tx);
       bins B_WS[] = {[0:6]};
     }
 
+    B_HANDSHAKE_CP : coverpoint (packet.b_wait_states == 0) {
+      option.comment = "BREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     AR_WAIT_STATES_CP : coverpoint packet.ar_wait_states {
       option.comment = "ARREADY wait states";
       bins AR_WS[] = {[0:6]};
     }
 
+    AR_HANDSHAKE_CP : coverpoint (packet.ar_wait_states == 0) {
+      option.comment = "ARREADY handshake";
+      bins HANDSHAKE = {1};
+    }
+
     R_WAIT_STATES_CP : coverpoint packet.r_wait_states {
       option.comment = "RREADY wait states";
       bins R_WS[] = {[0:6]};
+    }
+
+    R_HANDSHAKE_CP : coverpoint (packet.r_wait_states == 0) {
+      option.comment = "RREADY handshake";
+      bins HANDSHAKE = {1};
     }
     
     TRANSFER_TYPE_CP : coverpoint packet.transfer_type {

--- a/test/axi4_ar_ready_delay_test.sv
+++ b/test/axi4_ar_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_ar_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_ar_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_READ_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_ar_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_aw_ready_delay_test.sv
+++ b/test/axi4_aw_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_aw_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_aw_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_aw_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_aw_w_channel_separation_test.sv
+++ b/test/axi4_aw_w_channel_separation_test.sv
@@ -6,6 +6,11 @@ class axi4_aw_w_channel_separation_test extends axi4_base_test;
 
   axi4_virtual_aw_w_channel_separation_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_aw_w_channel_separation_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_b_ready_delay_test.sv
+++ b/test/axi4_b_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_b_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_b_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_b_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_r_ready_delay_test.sv
+++ b/test/axi4_r_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_r_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_r_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_READ_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_r_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction

--- a/test/axi4_w_ready_delay_test.sv
+++ b/test/axi4_w_ready_delay_test.sv
@@ -6,6 +6,11 @@ class axi4_w_ready_delay_test extends axi4_base_test;
 
   axi4_virtual_w_ready_delay_seq vseq;
 
+  function void setup_axi4_env_cfg();
+    super.setup_axi4_env_cfg();
+    axi4_env_cfg_h.write_read_mode_h = ONLY_WRITE_DATA;
+  endfunction: setup_axi4_env_cfg
+
   function new(string name="axi4_w_ready_delay_test", uvm_component parent=null);
     super.new(name,parent);
   endfunction


### PR DESCRIPTION
## Summary
- add handshake coverpoints in master and slave coverage
- sweep wait states in ready delay sequences for complete coverage

## Testing
- `make -f sim/questasim/makefile compile` *(fails: `vlib` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c409e54888320b4ec6452bb4d6f8b