### PR TITLE
Enable slave memory mode for WSTRB tests

### DIFF
--- a/test/axi4_wstrb_all_ones_test.sv
+++ b/test/axi4_wstrb_all_ones_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_all_ones_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_all_zero_test.sv
+++ b/test/axi4_wstrb_all_zero_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_all_zero_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_alternating_test.sv
+++ b/test/axi4_wstrb_alternating_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_alternating_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_illegal_test.sv
+++ b/test/axi4_wstrb_illegal_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_illegal_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_lower_half_test.sv
+++ b/test/axi4_wstrb_lower_half_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_lower_half_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_random_burst_test.sv
+++ b/test/axi4_wstrb_random_burst_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_random_burst_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_single_bit_test.sv
+++ b/test/axi4_wstrb_single_bit_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_single_bit_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;

--- a/test/axi4_wstrb_upper_half_test.sv
+++ b/test/axi4_wstrb_upper_half_test.sv
@@ -11,6 +11,12 @@ class axi4_wstrb_upper_half_test extends axi4_base_test;
     super.new(name,parent);
   endfunction
 
+  function void setup_axi4_slave_agent_cfg();
+    super.setup_axi4_slave_agent_cfg();
+    foreach(axi4_env_cfg_h.axi4_slave_agent_cfg_h[i])
+      axi4_env_cfg_h.axi4_slave_agent_cfg_h[i].read_data_mode = SLAVE_MEM_MODE;
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     axi4_env_cfg_h.wstrb_compare_enable = 1;


### PR DESCRIPTION
## Summary
- update WSTRB tests so the slave uses its internal memory
- this allows memory write/read debug messages to appear when verbosity is high

## Testing
- `make -C sim/questasim -n simulate test=axi4_wstrb_all_zero_test`

------
https://chatgpt.com/codex/tasks/task_e_685dffb02c948320aa17713f2ee086a8